### PR TITLE
Make Offline Work Easier

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 	<head>
 		<title>Prototyping Boilerplate</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		<link rel="stylesheet" href="https://unpkg.com/normalize.css@8.0.0/normalize.css">
 		<link rel="stylesheet" href="/styles/styles.css">
 	</head>
 	<body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,14 +28,14 @@
       }
     },
     "ecstatic": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.0.tgz",
-      "integrity": "sha512-EblWYTd+wPIAMQ0U4oYJZ7QBypT9ZUIwpqli0bKDjeIIQnXDBK2dXtZ9yzRCOlkW1HkO8gn7/FxLK1yPIW17pw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "requires": {
-        "he": "1.2.0",
-        "mime": "1.6.0",
-        "minimist": "1.2.0",
-        "url-join": "2.0.5"
+        "he": "^1.1.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.1.0",
+        "url-join": "^2.0.5"
       }
     },
     "eventemitter3": {
@@ -48,7 +48,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
       "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "=3.1.0"
       }
     },
     "he": {
@@ -61,9 +61,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
-        "eventemitter3": "3.1.0",
-        "follow-redirects": "1.5.8",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-server": {
@@ -72,13 +72,13 @@
       "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
       "requires": {
         "colors": "1.0.3",
-        "corser": "2.0.1",
-        "ecstatic": "3.3.0",
-        "http-proxy": "1.17.0",
-        "opener": "1.4.3",
-        "optimist": "0.6.1",
-        "portfinder": "1.0.17",
-        "union": "0.4.6"
+        "corser": "~2.0.0",
+        "ecstatic": "^3.0.0",
+        "http-proxy": "^1.8.1",
+        "opener": "~1.4.0",
+        "optimist": "0.6.x",
+        "portfinder": "^1.0.13",
+        "union": "~0.4.3"
       }
     },
     "mime": {
@@ -88,7 +88,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
@@ -121,8 +121,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -137,9 +137,9 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
       "integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       },
       "dependencies": {
         "debug": {
@@ -167,7 +167,7 @@
       "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
       "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
       "requires": {
-        "qs": "2.3.3"
+        "qs": "~2.3.3"
       }
     },
     "url-join": {

--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,24 @@
 # Prototyping Boilerplate
 
-I made this as a quick alternative to both browser based prototyping tools and setting up a build system every time you want to experiment.
+This is a quick alternative to either browser based IDEs or setting up a build system every time you want to experiment.
 
 It makes the assumption that you are using a modern browser which supports both ES Modules and CSS Custom Properties. If your prototype is a success, you can package those same modules using your build system of choice.
 
 ## Minimal Requirements
 
 - Git
-- Node and NPM
-- `http-server` is the only NPM dependency.
+- HTTP server of choice
 
 ## Get Started
 
-- `$ git clone https://github.com/thoughtis/prototyping-boilerplate.git`
-- `$ npm install`
-- `$ npm run start` to serve locally using `http-server`
+- `$ git clone https://github.com/thoughtis/prototyping-boilerplate.git your-project-name`
+
+### HTTP Server
+
+- If you have PHP or Python installed, you can use their built in HTTP server without install anything else.
+- Otherwise
+  - `$ npm install`
+  - `$ npm run start` to serve locally using `http-server`
 
 ## Scripting
 
@@ -23,7 +27,5 @@ This boilerplate uses ECMAScript Modules in the browser. See [this post](https:/
 > Note: My example modules use strict mode in each module. This is a personal choice and may not be required.
 
 ## Styling
-
-For consistency's sake, [normalize.css](https://github.com/necolas/normalize.css/) is included via CDN.
 
 No magic here, just use custom properties if you need variables, and you can get them ready for production later.

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -2,9 +2,8 @@
  * Prototyping Boilerplate
  */
 
-:root{
+:root {
 	--line-height-base: 1.5;
-	--line-height-heading: 1.25;
 }
 
 /**
@@ -22,18 +21,9 @@ html {
 }
 
 /**
- * Override opinionated normalize.css line-heights
+ * Example of Custom Property
  */
 
-html,
-button,
-input,
-optgroup,
-select,
-textarea{
-	line-height: var(--line-height-base);
-}
-
-h1 {
-	line-height: var(--line-height-heading);
+body {
+	line-height: var(--line-height-base);	
 }


### PR DESCRIPTION
### Background

In order to make this thing work a little better with low-to-no internet, I'm removing http requests and updating the readme to suggest skipping npm install. 

### What Was Accomplished

- Removed Normalize since it was served from CDN. 
- Updated readme to suggest users utilize a previously installed http server if they want to avoid the extra npm dependencies. 